### PR TITLE
複数の同盟が作成できない不具合の修正

### DIFF
--- a/app/model/hako-log.php
+++ b/app/model/hako-log.php
@@ -773,7 +773,7 @@ class Log extends LogIO {
 	}
 	// 船失敗
 	function shipFail($id, $name, $comName, $kind) {
-		$this->out("<A href=\"{$this->this_file}?Sight={$id}\">{$this->init->tagName_}{$name}{$this->init->nameSuffix}</A>{$this->init->_tagName}で予定されていた{$this->init->tagComName_}{$comName}{$this->init->_tagComName}は、<strong>{$kind}</strong>だったため中止されました。",$id, $tId);
+		$this->out("<A href=\"{$this->this_file}?Sight={$id}\">{$this->init->tagName_}{$name}{$this->init->nameSuffix}</A>{$this->init->_tagName}で予定されていた{$this->init->tagComName_}{$comName}{$this->init->_tagComName}は、<strong>{$kind}</strong>だったため中止されました。",$id);
 	}
 	// ぞらす現る
 	function ZorasuCome($id, $name, $point) {

--- a/app/presenter/hako-html.php
+++ b/app/presenter/hako-html.php
@@ -2292,7 +2292,7 @@ END;
     //--------------------------------------------------
     // 同盟の状況
     //--------------------------------------------------
-    public function allyInfo($hako, $num = 0)
+    public function allyInfo($hako, $view_ally_num = 0)
     {
         global $init;
         $this_file  = $init->baseDir . "/hako-ally.php";
@@ -2326,7 +2326,7 @@ END;
 END;
 
         for ($i=0; $i<$allyNumber; $i++) {
-            if ($num && ($i != $hako->idToAllyNumber[$num])) {
+            if ($view_ally_num && ($i != $hako->idToAllyNumber[$view_ally_num])) {
                 continue;
             }
             $ally = $hako->ally[$i];

--- a/hako-ally.php
+++ b/hako-ally.php
@@ -92,7 +92,7 @@ class MakeAlly
             HakoError::noMoney();
             return;
         }
-        $n = $hako->idToAllyNumber[$currentID];
+        $n = $hako->idToAllyNumber[$currentID] ?? '';
         if ($n != '') {
             if ($adminMode && ($allyID != '') && ($allyID < 200)) {
                 $allyMember = $hako->ally[$n]['memberId'];
@@ -673,9 +673,13 @@ class AllyIO
         fputs($fp, $ext . "\n");
         if (isset($ally['comment'])) {
             fputs($fp, $ally['comment'] . "\n");
+        }else {
+            fputs($fp, "\n");
         }
         if (isset($ally['title']) && isset($ally['message'])) {
             fputs($fp, $ally['title'] . '<>' . $ally['message'] . "\n");
+        }else {
+            fputs($fp, '<>'. "\n");
         }
     }
 
@@ -1121,11 +1125,11 @@ $start->execute();
 // 人口を比較、同盟一覧用
 function scoreComp($x, $y)
 {
-    if ($x['dead'] == 1) {
+    if (isset($x['dead']) && $x['dead'] == 1) {
         // 死滅フラグが立っていれば後ろへ
         return +1;
     }
-    if ($y['dead'] == 1) {
+    if (isset($y['dead']) && $y['dead'] == 1) {
         return -1;
     }
     if ($x['score'] == $y['score']) {


### PR DESCRIPTION
#1

1つ目の同盟のコメント・タイトル・メッセージのいずれかが書き込まれていない場合にファイルが正常に作成されず、読み込み時に2つ目以降の同盟が読み込めなくなっていた。