### PR TITLE
海賊船存在判定が常時ONになってる不具合修正

### DIFF
--- a/app/controller/admin/mente.php
+++ b/app/controller/admin/mente.php
@@ -185,8 +185,8 @@ class Mente extends \Admin
             HakoError::wrongSpecialPassword();
             return;
         }
-        $masterPasswd  = Util::encode($this->dataSet['MPASS1'], false);
-        $specialPasswd = Util::encode($this->dataSet['SPASS1'], false);
+        $masterPasswd  = \Util::encode($this->dataSet['MPASS1'], false);
+        $specialPasswd = \Util::encode($this->dataSet['SPASS1'], false);
         $fp = fopen($init->passwordFile, "w");
         fputs($fp, "$masterPasswd\n");
         fputs($fp, "$specialPasswd\n");

--- a/app/helper/util.php
+++ b/app/helper/util.php
@@ -360,7 +360,7 @@ class Util
         $badShipsId = $init->shipKind;
         $badShips   = 0;
         for ($i=$badShipsId; $i < $arrSize; $i++) {
-            $badShips++;
+            if (is_numeric($ships[$i]) && $ships[$i] > 0) $badShips++;
         }
         return ($badShips!=0);
     }

--- a/app/model/hako-turn.php
+++ b/app/model/hako-turn.php
@@ -5294,9 +5294,9 @@ class Turn {
                 if((($sy % 2) == 0) && (($y % 2) == 1)) {
                     $sx--;
                 }
-                $landKind = $land[$sx][$sy];
-                $lv = $landValue[$sx][$sy];
-                $point = "({$sx}, {$sy})";
+                //$landKind = $land[$sx][$sy];
+                //$lv = $landValue[$sx][$sy];
+                //$point = "({$sx}, {$sy})";
 
                 if(($sx < 0) || ($sx >= $init->islandSize) ||
                     ($sy < 0) || ($sy >= $init->islandSize)) {


### PR DESCRIPTION
なんで人口１万より増えんのやろうなぁー絶対に現代都市にならんやんこれおかしいやんーって思ってデバッグしました。悲しいなぁ。

あとついでにデバッグ用に初期化しようとしたら初期化もできんくなってたので直しました